### PR TITLE
ci(.github): se correct api docs diff make target names

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:
           fetch-depth: 0
-      - run: make api-docs
+      - run: make apidocs-capsule
+      - run: make apidocs-capsule-proxy
       - name: Checking if the CRDs documentation is not aligned
         run: if [[ $(git diff | wc -l) -gt 0 ]]; then echo ">>> CRDs generated documentation have not been committed" && git --no-pager diff && exit 1; fi

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: '0.120.4'
           extended: true
@@ -46,7 +46,7 @@ jobs:
         run: sudo snap install dart-sass
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Install Node.js dependencies
         run: " npm install --save-dev autoprefixer postcss-cli && npm ci || true"
       - name: Update Hugo Modules
@@ -62,7 +62,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./public
 
@@ -76,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Temporary directory for cloning
 
 fetch-capsule: REF      ?= main
-fetch-capsule: REPO_URL ?= git@github.com:projectcapsule/capsule.git
+fetch-capsule: REPO_URL ?= https://github.com/projectcapsule/capsule.git
 fetch-capsule: fetch
 
 fetch-capsule-proxy: REF      ?= main
-fetch-capsule-proxy: REPO_URL ?= git@github.com:projectcapsule/capsule-proxy.git
+fetch-capsule-proxy: REPO_URL ?= https://github.com/projectcapsule/capsule-proxy.git
 fetch-capsule-proxy: fetch
 
 fetch:


### PR DESCRIPTION
This PR fixes API docs Make target names and ensures all the GitHub Actions are pinned.

Furthermore, it updates the URL of Capsule and Capsule Proxy repositories to HTTPS, from SSH.

Fixes #5 