### PR TITLE
fix: rename oil tenant into solar

### DIFF
--- a/content/en/docs/tenants/quickstart.md
+++ b/content/en/docs/tenants/quickstart.md
@@ -12,7 +12,7 @@ kubectl create -f - << EOF
 apiVersion: capsule.clastix.io/v1beta2
 kind: Tenant
 metadata:
-  name: oil
+  name: solar
 spec:
   owners:
   - name: alice


### PR DESCRIPTION
The next command `kubectl get tenants` shows a tenant named solar.