### PR TITLE
docs: fix trucated text in a quickstart sample yaml

### DIFF
--- a/content/en/docs/tenants/quickstart.md
+++ b/content/en/docs/tenants/quickstart.md
@@ -20,7 +20,8 @@ spec:
         team: platform
   owners:
   - name: alice
-    kind: Us
+    kind: User
+```
 
 You can check the tenant just created
 

--- a/content/en/docs/tenants/quickstart.md
+++ b/content/en/docs/tenants/quickstart.md
@@ -21,6 +21,7 @@ spec:
   owners:
   - name: alice
     kind: User
+EOF
 ```
 
 You can check the tenant just created


### PR DESCRIPTION
fixed trucated text in a sample yaml