### PR TITLE
chore: remove benchmark page

### DIFF
--- a/content/en/docs/guides/use-fluxcd.md
+++ b/content/en/docs/guides/use-fluxcd.md
@@ -566,8 +566,6 @@ Now let's go on with the practical part.
 He could try to use privileged `ServiceAccount` by changing ownership of a privileged Namespace so that he could create Reconciliation resource there and using the privileged SA.
 This is not permitted as he can't patch Namespaces which have not been created by him. Capsule request validation would not pass.
 
-For other protections against threats in this multi-tenancy scenario please see the Capsule [Multi-Tenancy Benchmark](/docs/overview/benchmark/).
-
 ## References
 - https://fluxcd.io/docs/installation/#multi-tenancy-lockdown
 - https://fluxcd.io/blog/2022/05/may-2022-security-announcement/

--- a/content/en/docs/overview/benchmark.md
+++ b/content/en/docs/overview/benchmark.md
@@ -2,8 +2,12 @@
 title: Benchmark
 weight: 10
 description: Multi-Tenancy Benchmark
+_build:
+  render: never
+  list: never
 ---
 
+## This page has been archived since it's not updated in a long time. Also, the Multi-Tenancy benchmark is in public archive. If you want to unarchive, remove the `_build` section in the header.
 
 The [Multi-Tenancy Benchmark](https://github.com/kubernetes-sigs/multi-tenancy) is a _WG_ (Working Group) committed to achieving multi-tenancy in Kubernetes.
 


### PR DESCRIPTION
The benchmark page is by far the most outdated page on the website, and just doesn't make sense anymore. Delete it for now, untill it gets a overhaul. 