### PR TITLE
fix(cicd): keep version dropdown in sync across release branches

### DIFF
--- a/.github/workflows/sync-version-switcher.yml
+++ b/.github/workflows/sync-version-switcher.yml
@@ -1,21 +1,19 @@
 name: Sync version switcher
 permissions: {}
 
-# Triggered automatically when the `version:` field in params.yaml changes on
-# main (i.e. a new release is cut), or manually for one-off runs.
+# Triggered automatically when params.yaml changes on main (i.e. a new release
+# is cut or the version switcher is edited), or manually for one-off runs.
+#
+# config/_default/params.yaml on main declares the desired version switcher.
+# This workflow opens (or updates) a PR against every release/<x.y> branch
+# replacing the branch's copy of the file, with the branch's own version and
+# archived flag stamped in. Replacing the whole file makes the sync
+# convergent: a branch that missed a run is healed on the next one.
 on:
   push:
     branches: [main]
     paths: ['config/_default/params.yaml']
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version label to add (e.g. v0.14)'
-        required: true
-      url:
-        description: 'URL for this version'
-        required: true
-        default: 'https://projectcapsule.dev'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,157 +28,85 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Determine version to sync
-        id: ver
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "url=${{ inputs.url }}" >> "$GITHUB_OUTPUT"
-          else
-            # Use github.event.before as the reliable baseline for the push.
-            # HEAD~1 breaks when multiple commits land in a single push.
-            OLD=$(git show "${{ github.event.before }}":config/_default/params.yaml 2>/dev/null \
-              | grep '^version:' | awk '{print $2}' || echo "")
-            NEW=$(grep '^version:' config/_default/params.yaml | awk '{print $2}')
-            if [ "$OLD" = "$NEW" ]; then
-              echo "Version unchanged ($NEW), nothing to sync"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "version=$NEW" >> "$GITHUB_OUTPUT"
-            echo "url=$(grep '^url_latest_version:' config/_default/params.yaml | awk '{print $2}')" \
-              >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Open PRs for all release branches
-        if: steps.ver.outputs.skip != 'true'
         env:
-          VERSION: ${{ steps.ver.outputs.version }}
-          URL: ${{ steps.ver.outputs.url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION_SLUG=$(echo "$VERSION" | sed 's/^v//;s/\./-/g')
+          set -euo pipefail
+
           REPO="${GITHUB_REPOSITORY}"
+          DESIRED_FILE=$(mktemp)
 
-          # Ensure all remote release branches are available locally
-          git fetch --prune origin
+          # Find all versioned release branches (release/x.y), skip preview branches
+          mapfile -t branches < <(git ls-remote --heads origin 'release/*' | sed 's|.*refs/heads/||')
 
-          # Find all versioned release branches (release/0.x), skip preview branches
-          for branch in $(git branch -r | grep -E 'origin/release/[0-9]' | sed 's|.*origin/||'); do
-            echo "::group::$branch"
-            git checkout -B "$branch" "origin/$branch"
-
-            WORK_BRANCH="chore/add-${VERSION_SLUG}-to-${branch//\//-}"
-
-            # Determine whether to open a new PR or update an existing one
-            if git ls-remote --exit-code origin "refs/heads/${WORK_BRANCH}" > /dev/null 2>&1; then
-              PR_ACTION="update"
-            else
-              PR_ACTION="create"
+          for branch in "${branches[@]}"; do
+            if [[ ! $branch =~ ^release/[0-9]+\.[0-9]+$ ]]; then
+              echo "$branch: does not match release/<x.y>, skipping"
+              continue
             fi
+            echo "::group::$branch"
 
-            python3 - <<'PYEOF'
-          import os, re
+            # Desired file for this branch: main's copy with the branch's own
+            # version stamped in. Always archived: main serves the latest at
+            # the apex, so every branch copy is an archived snapshot.
+            export VERSION="v${branch#release/}"
+            cp config/_default/params.yaml "$DESIRED_FILE"
+            yq -i '
+                .version = strenv(VERSION)
+              | .version_menu = strenv(VERSION)
+              | .archived_version = true
+            ' "$DESIRED_FILE"
 
-          version = os.environ['VERSION']
-          url     = os.environ['URL']
-
-          with open('config/_default/params.yaml') as f:
-              content = f.read()
-
-          # Repoint any version still pointing to projectcapsule.dev to its
-          # frozen release subdomain (it was a previous latest, now archived).
-          def frozen_url(ver):
-              slug = ver.lstrip('v').replace('.', '-')
-              return f"https://release-{slug}.projectcapsule.dev"
-
-          content = re.sub(
-              r'^(- version: (v[\d.]+)\n  url: https://projectcapsule\.dev)$',
-              lambda m: f"- version: {m.group(2)}\n  url: {frozen_url(m.group(2))}",
-              content,
-              flags=re.MULTILINE,
-          )
-
-          # Insert the new version only if not already present (idempotent).
-          if not re.search(r'^- version: ' + re.escape(version) + r'$', content, re.MULTILINE):
-              new_entry = f"- version: {version}\n  url: {url}\n"
-              content = re.sub(
-                  r'(^versions:\n)',
-                  r'\g<1>' + new_entry,
-                  content,
-                  flags=re.MULTILINE,
-                  count=1,
-              )
-
-          with open('config/_default/params.yaml', 'w') as f:
-              f.write(content)
-          PYEOF
-
-            # Check if there are actual changes vs the release branch HEAD
-            if git diff --quiet HEAD -- config/_default/params.yaml; then
+            # Skip the branch if its copy already matches (e.g. the sync PR
+            # was merged). Every release branch must have the file; if one
+            # does not, this fails the run rather than papering over it.
+            EXISTING=$(gh api "repos/${REPO}/contents/config/_default/params.yaml?ref=${branch}")
+            if jq -r '.content' <<< "$EXISTING" | base64 -d | cmp -s - "$DESIRED_FILE"; then
               echo "Already in desired state, skipping ${branch}"
-              git restore config/_default/params.yaml
               echo "::endgroup::"
               continue
             fi
 
-            # Save desired content to a temp file (preserves trailing newline)
-            DESIRED_FILE=$(mktemp)
-            cat config/_default/params.yaml > "$DESIRED_FILE"
-            git restore config/_default/params.yaml
+            WORK_BRANCH="chore/sync-version-switcher-${branch//\//-}"
 
             # --- API-based commit (GitHub auto-verifies; no GPG key needed) ---
 
-            # Get the release branch HEAD and its tree
+            # Point the work branch at the release branch HEAD, creating it if needed
             BASE_SHA=$(gh api "repos/${REPO}/branches/${branch}" --jq '.commit.sha')
-            BASE_TREE_SHA=$(gh api "repos/${REPO}/git/commits/${BASE_SHA}" --jq '.tree.sha')
-
-            # Upload the modified file as a blob
-            CONTENT_B64=$(base64 -w 0 < "$DESIRED_FILE")
-            rm -f "$DESIRED_FILE"
-            BLOB_SHA=$(gh api "repos/${REPO}/git/blobs" \
-              -f content="$CONTENT_B64" \
-              -f encoding="base64" \
-              --jq '.sha')
-
-            # Create a new tree with the updated file
-            NEW_TREE_SHA=$(jq -n \
-              --arg base_tree "$BASE_TREE_SHA" \
-              --arg blob "$BLOB_SHA" \
-              '{base_tree:$base_tree,tree:[{path:"config/_default/params.yaml",mode:"100644",type:"blob",sha:$blob}]}' | \
-              gh api "repos/${REPO}/git/trees" --input - --jq '.sha')
+            if git ls-remote --exit-code origin "refs/heads/${WORK_BRANCH}" > /dev/null 2>&1; then
+              gh api --silent "repos/${REPO}/git/refs/heads/${WORK_BRANCH}" \
+                -X PATCH -f sha="$BASE_SHA" -F force=true
+            else
+              gh api --silent "repos/${REPO}/git/refs" \
+                -f ref="refs/heads/${WORK_BRANCH}" \
+                -f sha="$BASE_SHA"
+            fi
 
             # Build commit message with Signed-off-by for DCO
-            COMMIT_MSG=$(printf 'chore: add %s to version switcher in %s\n\nSigned-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>' \
-              "$VERSION" "$branch")
+            COMMIT_MSG=$(printf 'chore: sync version switcher from main\n\nSigned-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>')
 
-            # Create the commit (GitHub signs API commits automatically → Verified)
-            NEW_COMMIT_SHA=$(jq -n \
-              --arg msg "$COMMIT_MSG" \
-              --arg tree "$NEW_TREE_SHA" \
-              --arg parent "$BASE_SHA" \
-              '{message:$msg,tree:$tree,parents:[$parent]}' | \
-              gh api "repos/${REPO}/git/commits" --input - --jq '.sha')
+            # Commit the desired file (GitHub signs API commits automatically → Verified)
+            gh api --silent -X PUT "repos/${REPO}/contents/config/_default/params.yaml" \
+              -f branch="$WORK_BRANCH" \
+              -f message="$COMMIT_MSG" \
+              -f content="$(base64 -w 0 "$DESIRED_FILE")" \
+              -f sha="$(jq -r '.sha' <<< "$EXISTING")"
 
-            # Create or force-update the work branch ref
-            if [ "$PR_ACTION" = "update" ]; then
-              gh api "repos/${REPO}/git/refs/heads/${WORK_BRANCH}" \
-                -X PATCH -f sha="$NEW_COMMIT_SHA" -F force=true
-              echo "Updated PR branch: ${WORK_BRANCH}"
-            else
-              gh api "repos/${REPO}/git/refs" \
-                -f ref="refs/heads/${WORK_BRANCH}" \
-                -f sha="$NEW_COMMIT_SHA"
+            # Open a PR unless one is already open (re-runs update the same PR)
+            OPEN_PRS=$(gh pr list --repo "$REPO" --base "$branch" --head "$WORK_BRANCH" \
+              --state open --json number --jq 'length')
+            if [[ $OPEN_PRS -eq 0 ]]; then
               gh pr create \
                 --repo "$REPO" \
                 --base "$branch" \
                 --head "$WORK_BRANCH" \
-                --title "chore: add ${VERSION} to version switcher in ${branch}" \
-                --body "Automated PR: adds \`${VERSION}\` to the version switcher in the \`${branch}\` release docs. Triggered by: ${{ github.event_name }} (${{ github.sha }})"
+                --title "chore: sync version switcher in ${branch}" \
+                --body "Automated PR: syncs the version switcher from \`config/_default/params.yaml\` on main, stamping this branch's version. Triggered by: ${{ github.event_name }} (${{ github.sha }})"
               echo "Opened PR: ${WORK_BRANCH} -> ${branch}"
+            else
+              echo "Updated PR branch: ${WORK_BRANCH}"
             fi
 
             echo "::endgroup::"

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -1,3 +1,8 @@
+# Hand-edit this file on main only. When it changes on main,
+# .github/workflows/sync-version-switcher.yml opens a PR against every
+# release/<x.y> branch, copying the file with the branch's own `version`,
+# `version_menu` and `archived_version` stamped in.
+
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.
 version_menu: "Releases"


### PR DESCRIPTION
#107 added a workflow that opens PRs to add each new release to the
version switcher on the release branches. This PR takes that one step
further, from imperative to declarative: instead of appending a dropdown
entry per release, `config/_default/params.yaml` on main declares the
desired state, and the workflow copies the whole file to each
`release/<x.y>` branch (still one PR per branch), with the branch's own
`version` and `archived_version` filled in.

Since every sync converges on the declared state instead of applying an
edit, we get a few things for free:

- Versions removed from the list on main disappear from all branches
  automatically.
- A branch that missed a run (or merged PRs out of order) is corrected
  by the next one.
- Any change to the dropdown — renaming an entry, changing a URL — is a
  normal edit on main, no workflow changes needed.
- The archived-version banner now shows on old branches.

See the created PRs at https://github.com/LorenzBischof/capsule-website/pulls

Notice that this would mean the current release should live on `main`, while the release tags would only be added after a new release.